### PR TITLE
Fixed an issue with config not being applied

### DIFF
--- a/picar_4wd/__init__.py
+++ b/picar_4wd/__init__.py
@@ -12,7 +12,7 @@ from picar_4wd.utils import *
 import time
 
 # Config File:
-config = FileDB("~/.picar-4wd-config")
+config = FileDB("config")
 left_front_reverse = config.get('left_front_reverse', default_value = False)
 right_front_reverse = config.get('right_front_reverse', default_value = False)
 left_rear_reverse = config.get('left_rear_reverse', default_value = False)


### PR DESCRIPTION
During setup, the config is copied from `data/config` to `~/.picar-4wd/config`, and as a result of it being named differently in the code, it wasn't applied. This pull request is fixing it.